### PR TITLE
Proxychain localnet

### DIFF
--- a/proxychains/core.h
+++ b/proxychains/core.h
@@ -38,6 +38,7 @@ typedef enum {RANDOMLY,FIFOLY} select_type;
 typedef struct
 {
 	struct in_addr in_addr, netmask;
+	unsigned short port;
 } localaddr_arg;
 
 typedef struct

--- a/proxychains/proxychains.conf
+++ b/proxychains/proxychains.conf
@@ -41,6 +41,16 @@ proxy_dns
 tcp_read_time_out 15000
 tcp_connect_time_out 8000
 
+# Example for localnet exclusion
+## Exclude connections to 192.168.1.0/24 with port 80
+# localnet 192.168.1.0:80/255.255.255.0
+
+## Exclude connections to 192.168.100.0/24
+# localnet 192.168.100.0/255.255.255.0
+
+## Exclude connections to ANYwhere with port 80
+# localnet 0.0.0.0:80/0.0.0.0
+
 # ProxyList format
 #       type  host  port [user pass]
 #       (values separated by 'tab' or 'blank')


### PR DESCRIPTION
Hi, haad

I've updated the localnet-patch to support 'port exclusion' as a friend from internet mailed me. Now, we can write configuration like

localnet 192.168.1.0:80/255.255.255.0

to exclude connections to 192.168.1.0/24 subnet with port 80, or even

localhost 0.0.0.0:80/0.0.0.0

to redirect all connections to SOCKS server except connections to port 80.
