### PR TITLE
Fixes issues with compiling in Mint 14

### DIFF
--- a/configure
+++ b/configure
@@ -105,8 +105,8 @@ fi
 
 if islinux ; then
     #echo OS_CFLAGS=
-    echo OS_LDFLAGS=-pthread -ldl -Wl,--no-as-needed>>config.mak
-    echo LD_SET_SONAME=-install_name, >>config.mak
+    echo OS_LDFLAGS=-pthread -Wl,--no-as-needed -ldl>>config.mak
+    #echo LD_SET_SONAME=-install_name, >>config.mak
 fi
 
 if isbsd ; then


### PR DESCRIPTION
- unrecognized command line option '-install_name,libproxychains4.so'
- symbol lookup error: ./libproxychains4.so: undefined symbol: dlsym
