### PR TITLE
Allow user to override default DNS server

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -160,3 +160,13 @@ $ PROXYCHAINS_SOCKS5=4321 proxychains zsh
 
 in this example, it will run a shell with all traffic proxied through
 OpenSSH's "dynamic proxy" (SOCKS5 proxy) on localhost port 4321.
+
+=== Usage Example:
+
+----
+$ export PROXY_DNS_SERVER=8.8.8.8
+$ proxychains telnet targethost.com
+----
+
+in this example, it will telnet to targethost.com using the 8.8.8.8
+nameserver supplied by the user through the PROXY_DNS_SERVER

--- a/src/proxyresolv
+++ b/src/proxyresolv
@@ -3,12 +3,11 @@
 
 # DNS server used to resolve names
 
-if [[ -z "$PROXY_DNS_SERVER" ]] ; then
+if [ -z "$PROXY_DNS_SERVER" ] ; then
     DNS_SERVER=208.67.222.222   # OpenDNS
 else
     DNS_SERVER=$PROXY_DNS_SERVER
 fi
-
 
 if [ $# = 0 ] ; then
 	echo "	usage:"
@@ -17,7 +16,7 @@ if [ $# = 0 ] ; then
 fi
 
 awk 'BEGIN{ARGC=0} {for(i=2;i<=NF;i++){if($i==ARGV[1] && $1!~":"){print $1;found=1}} } END{exit found?0:1}' "$1" </etc/hosts
-if [[ "$?" -eq "0" ]]; then
+if [ "$?" -eq "0" ]; then
         exit
 fi
 

--- a/src/proxyresolv
+++ b/src/proxyresolv
@@ -2,7 +2,12 @@
 # This script is called by proxychains to resolve DNS names
 
 # DNS server used to resolve names
-DNS_SERVER=208.67.222.222
+
+if [[ -z "$PROXY_DNS_SERVER" ]] ; then
+    DNS_SERVER=208.67.222.222   # OpenDNS
+else
+    DNS_SERVER=$PROXY_DNS_SERVER
+fi
 
 
 if [ $# = 0 ] ; then


### PR DESCRIPTION
Implements support for an environment variable (PROXY_DNS_SERVER) whereby the user can specify a DNS server. If not set defaults to the hardcoded OpenDNS default.
