### PR TITLE
Fix type on proxychains.conf fix_conf_file_type

### DIFF
--- a/src/proxychains.conf
+++ b/src/proxychains.conf
@@ -91,7 +91,7 @@ localnet 127.0.0.0/255.0.0.0
 #
 [ProxyList]
 # add proxy here ...
-# meanwile
+# meanwhile
 # defaults set to "tor"
 socks4 	127.0.0.1 9050
 


### PR DESCRIPTION
Small typo in default proxychains.conf file