### PR TITLE
support 'raw' proxy type

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -278,6 +278,10 @@ static int tunnel_to(int sock, ip_type ip, unsigned short port, proxy_type pt, c
 	//memset (buff, 0, sizeof(buff));
 
 	switch (pt) {
+		case RAW_TYPE: {
+			return SUCCESS;
+		}
+		break;
 		case HTTP_TYPE:{
 				if(!dns_len) {
 					inet_ntop(AF_INET, &ip.octet[0], ip_buf, sizeof(ip_buf));

--- a/src/core.h
+++ b/src/core.h
@@ -67,6 +67,7 @@ typedef enum {
 
 typedef enum {
 	HTTP_TYPE,
+	RAW_TYPE,
 	SOCKS4_TYPE,
 	SOCKS5_TYPE
 } proxy_type;

--- a/src/libproxychains.c
+++ b/src/libproxychains.c
@@ -221,6 +221,8 @@ static void get_chain_data(proxy_data * pd, unsigned int *proxy_count, chain_typ
 
 				if(!strcmp(type, "http")) {
 					pd[count].pt = HTTP_TYPE;
+				} else if(!strcmp(type, "raw")) {
+					pd[count].pt = RAW_TYPE;
 				} else if(!strcmp(type, "socks4")) {
 					pd[count].pt = SOCKS4_TYPE;
 				} else if(!strcmp(type, "socks5")) {


### PR DESCRIPTION
Hello!

We have a use case where we want to use proxychains with a proxy that does not support CONNECT (some kubernetes-ingress-nginx thigny).

This implementation covers our use case perfectly.

Sending the PR in case you find this useful or if you have feedback.

Thanks for maintaining proxychains :)

Cheers,