### PR TITLE
fix GCC strncpy warnings

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -829,7 +829,7 @@ struct hostent *proxy_gethostbyname(const char *name, struct gethostbyname_data*
 
 	MUTEX_UNLOCK(&internal_ips_lock);
 
-	strncpy(data->addr_name, name, sizeof(data->addr_name));
+	strncpy(data->addr_name, name, sizeof(data->addr_name) - 1);
 
 	data->hostent_space.h_name = data->addr_name;
 	data->hostent_space.h_length = sizeof(in_addr_t);
@@ -914,7 +914,7 @@ int proxy_getaddrinfo(const char *node, const char *service, const struct addrin
 
 	p->ai_addr = &space->sockaddr_space;
 	if(node)
-		strncpy(space->addr_name, node, sizeof(space->addr_name));
+		strncpy(space->addr_name, node, sizeof(space->addr_name) - 1);
 	p->ai_canonname = space->addr_name;
 	p->ai_next = NULL;
 	p->ai_family = space->sockaddr_space.sa_family = AF_INET;


### PR DESCRIPTION
Recent GCC added checks for this and it triggers `Werror` with

```
In function 'strncpy',
    inlined from 'proxy_gethostbyname' at src/core.c:832:2:
/nix/store/hayaj8q9rc7swx4llcjqymmg3zr525lx-glibc-2.32-25-dev/include/bits/string_fortified.h:91:10: error: '__builtin_strncpy' specified bound 8192 equals destination size [8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wstringop-truncation-Werror=stringop-truncation8;;]
   91 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In function 'strncpy',
    inlined from 'proxy_getaddrinfo' at src/core.c:917:3:
/nix/store/hayaj8q9rc7swx4llcjqymmg3zr525lx-glibc-2.32-25-dev/include/bits/string_fortified.h:91:10: error: '__builtin_strncpy' specified bound 256 equals destination size [8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wstringop-truncation-Werror=stringop-truncation8;;]
   91 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
```