### PR TITLE
Reinitialise i before using it for iterating over dll_dirs

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -107,6 +107,7 @@ int main(int argc, char *argv[]) {
 	// search DLL
 	set_own_dir(argv[0]);
 
+	i = 0;
 	while(dll_dirs[i]) {
 		snprintf(buf, sizeof(buf), "%s/%s", dll_dirs[i], dll_name);
 		if(access(buf, R_OK) != -1) {


### PR DESCRIPTION
Previously, the value of it was kept from the loop over all the command-line arguments; as `/usr/lib` or `/lib` were far enough in the list, on many systems there was no difference, but `own_dir` and `LIB_DIR` could be ignored or not based on the argument count, which was confusing.