### PR TITLE
Fix GCC errors in DEBUG mode

### DIFF
--- a/configure
+++ b/configure
@@ -80,7 +80,7 @@ if [ -z "$CC" ] ; then
 fi
 
 if [ $develflg -eq 1 ]; then
-	CFLAGS="-Wextra -Wunused -Wuninitialized -Wconversion -fno-common -g -O0"
+	CFLAGS="-Wextra -Wunused -Wuninitialized -Wconversion -fno-common -g -O0 -DDEBUG"
 fi
 
 echo CC?=$CC>config.mak

--- a/src/core.c
+++ b/src/core.c
@@ -528,7 +528,7 @@ unsigned int get_rand_int(unsigned int range){
 	return (randval % range);
     } else {
 	srand((unsigned int)time(NULL));
-	return (rand() % range);
+	return ((unsigned int)rand() % range);
     }
 }
 
@@ -906,7 +906,7 @@ int proxy_getaddrinfo(const char *node, const char *service, const struct addrin
 	if(service)
 		proxy_getservbyname(service, &se_buf, buf, sizeof(buf), &se);
 
-	port = se ? se->s_port : htons(atoi(service ? service : "0"));
+	port = se ? se->s_port : htons((uint16_t)atoi(service ? service : "0"));
 	((struct sockaddr_in *) &space->sockaddr_space)->sin_port = (in_port_t)port;
 
 	*res = p = &space->addrinfo_space;

--- a/src/libproxychains.c
+++ b/src/libproxychains.c
@@ -335,14 +335,14 @@ static void get_chain_data(proxy_data * pd, unsigned int *proxy_count, chain_typ
 
 						if(dnat_orig_port[0]) {
 							dnats[num_dnats].orig_port =
-							    (short) atoi(dnat_orig_port);
+							    (unsigned short) atoi(dnat_orig_port);
 						} else {
 							dnats[num_dnats].orig_port = 0;
 						}
 
 						if(dnat_new_port[0]) {
 							dnats[num_dnats].new_port =
-							    (short) atoi(dnat_new_port);
+							    (unsigned short) atoi(dnat_new_port);
 						} else {
 							dnats[num_dnats].new_port = 0;
 						}


### PR DESCRIPTION
When we open debug mode(`./configure --devel`),
GCC will check `sign-conversion` and `conversion`.
It will cause some warnings.

Also add `-DDEBUG` to `CFLAGS` if we open debug
mode. This can open `PDEBUG()` and help you to get
detail information.

Signed-off-by: Jack Hu <spcreply@126.com>